### PR TITLE
feat: support any input

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,6 +1,5 @@
-#! /bin/bash -e
+#! /bin/bash
 
-temp_manifest_name=/tmp/manifest.yaml
 helm_options=()
 datree_options=()
 helm_chart_location=""
@@ -9,31 +8,23 @@ eoo=0
 
 while [[ $1 ]]; do
     if ! ((eoo)); then
-        case "$1" in
-        version | help | --help | config)
-            $HELM_PLUGIN_DIR/bin/datree $@
-            exit
-            ;;
-        test)
-            datree_command="$1"
-            helm_chart_location="$2"
-            shift 2
-            ;;
-        --)
+        if [[ $1 == "--" ]]; then
             eoo=1
-            shift
-            ;;
-        *)
+        elif [[ $helm_chart_location == "" && $(helm show chart $1 2> /dev/null) != "" ]]; then
+            helm_chart_location=$1
+        else 
             datree_options+=("$1")
-            shift
-            ;;
-        esac
+        fi
+
+        shift
     else
         helm_options+=("$1")
         shift
     fi
 done
 
-helm template "$helm_chart_location" "${helm_options[@]}" > ${temp_manifest_name}
-
-$HELM_PLUGIN_DIR/bin/datree $datree_command "$temp_manifest_name" "${datree_options[@]}"
+if [[ ${helm_chart_location} != "" ]]; then
+    helm template "$helm_chart_location" "${helm_options[@]}" | $HELM_PLUGIN_DIR/bin/datree "${datree_options[@]}" -
+else
+    $HELM_PLUGIN_DIR/bin/datree "${datree_options[@]}"
+fi


### PR DESCRIPTION
* Support any current and future commands and flags for `datree`
* Forward correct data output from datree to the user
* Kept previous behavior -> any use of helm flags after `--` works
* No specific order for the user to input command with chart. for example:`helm datree test -o json -p somePolicy <chart>` works