### PR TITLE
Support other helm commands (#23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ helm datree version
 helm datree help
 ```
 
+### Using other helm command
+Helm might be installed through other tooling like microk8s. The `DATREE_HELM_COMMAND` allows specifying a command to run helm (default: `helm`):
+```
+DATREE_HELM_COMMAND="microk8s helm3" helm datree test [CHART_DIRECTORY]
+```
+
 ## Example
 
 ```

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -9,13 +9,15 @@ helm_chart_name=""
 datree_command=""
 eoo=0
 
+helm_command=${DATREE_HELM_COMMAND:-helm}
+
 while [[ $1 ]]; do
     if ! ((eoo)); then
         if [[ $1 == "--" ]]; then
             eoo=1
-        elif [[ $helm_chart_location == "" && $(helm show chart $1 2> /dev/null | grep apiVersion) == apiVersion* ]]; then
+        elif [[ $helm_chart_location == "" && $($helm_command show chart $1 2> /dev/null | grep apiVersion) == apiVersion* ]]; then
             helm_chart_location=$1
-            helm_chart_name=$(helm show chart $1 | grep -o '^name: .*' | cut -c 7-)
+            helm_chart_name=$($helm_command show chart $1 | grep -o '^name: .*' | cut -c 7-)
         else
             datree_options+=("$1")
         fi
@@ -30,7 +32,7 @@ done
 if [[ ${helm_chart_location} != "" ]]; then
     currUinxTimestamp=$(date +%s)
     tempManifestPath="/tmp/${helm_chart_name}_$currUinxTimestamp.yaml"
-    helm template "${helm_options[@]}" "$helm_chart_location" > $tempManifestPath
+    $helm_command template "${helm_options[@]}" "$helm_chart_location" > $tempManifestPath
     $HELM_PLUGIN_DIR/bin/datree "${datree_options[@]}" $tempManifestPath
 else
     $HELM_PLUGIN_DIR/bin/datree "${datree_options[@]}"


### PR DESCRIPTION
This PR adds support for specifying alternative helm commands to allow using the plugin with helm from other tooling like microk8s by adding an environment variable called `DATREE_HELM_COMMAND`.

Closes #23 