### PR TITLE
Make scripts portable between different Linux distributions

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,6 @@
-#! /bin/bash -e
+#!/usr/bin/env bash
+
+set -e
 
 cd $HELM_PLUGIN_DIR
 echo "Installing helm-datree..."

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 


### PR DESCRIPTION
Use Bash from the system environment. Not every Linux distribution has Bash in the `/bin/bash` path (for example, NixOS).